### PR TITLE
OPT Unifies the `config` keywords for cards

### DIFF
--- a/src/ohmycards/web/kws/services/fetch_cards/core.cljs
+++ b/src/ohmycards/web/kws/services/fetch_cards/core.cljs
@@ -4,12 +4,11 @@
 (def cards "An array with the fetched cards." ::cards)
 (def error-message "An error message. If set on the response signals a failed fetch."
   ::error-message)
-;; !!!! TODO All those are repeated from cards-grid config
-;; !!!! /home/vitor/mygit/oh-my-cards-web/src/ohmycards/web/kws/cards_grid/config/core.cljs
-;; !!!! we should just use it!         
+
+(def config
+  "The configuration used to fetch the cards, as of `ohmycards.web.kws.cards-grid.config.core`."
+  ::config)
+
 (def page "The current page of fetched cards." ::page)
 (def page-size "The current number of cards per page." ::page-size)
-(def include-tags "Tags that must be on the fetched cards" ::include-tags)
-(def exclude-tags "Tags that must be NOT on the fetched cards" ::exclude-tags)
 (def count-of-cards "The total number of cards available (in the BE)" ::count-of-cards)
-(def tags-filter-query "A query for filtering the tags." ::tags-filter-query)

--- a/src/ohmycards/web/kws/views/cards_grid/core.cljs
+++ b/src/ohmycards/web/kws/views/cards_grid/core.cljs
@@ -3,18 +3,11 @@
 (def error-message "User friendly error msg" ::error-message)
 (def fetch-cards! "The function/service used to fetch cards." ::fetch-cards!)
 (def cards "An array with all fetched cards." ::cards)
+(def config "The cards grid config, as of `kws.cards-grid.config.core`" ::config)
 
-;; !!!! TODO All those are repeated from cards-grid config
-;; !!!! /home/vitor/mygit/oh-my-cards-web/src/ohmycards/web/kws/cards_grid/config/core.cljs
-;; !!!! we should just use it!         
-(def page "The current page of cards the user is seeing." ::page)
-(def page-size "The number of cards per page the user is seeing." ::page-size)
-(def include-tags "Tags that all cards must include." ::include-tags)
-(def exclude-tags "Tags that all cards must NOT include." ::exclude-tags)
-(def tags-filter-query "A query for filtering the tags." ::tags-filter-query)
 (def count-of-cards "The total number of cards available for the state." ::count-of-cards)
-(def status "A keyword indicating the current status for the state." ::status)
 
+(def status "A keyword indicating the current status for the state." ::status)
 (def status-ready "A keyword indicating the state management is done.." ::ready)
 (def status-error "A keyword indicating the state management is finished with error" ::error)
 

--- a/src/ohmycards/web/services/fetch_cards/core.cljs
+++ b/src/ohmycards/web/services/fetch_cards/core.cljs
@@ -2,6 +2,7 @@
   (:require [cljs.core.async :as a]
             [ohmycards.web.common.cards.core :as common.cards]
             [ohmycards.web.kws.card :as kws.card]
+            [ohmycards.web.kws.cards-grid.config.core :as kws.config]
             [ohmycards.web.kws.http :as kws.http]
             [ohmycards.web.kws.services.fetch-cards.core :as kws]
             [ohmycards.web.services.http.utils :as http.utils]))
@@ -11,11 +12,16 @@
 
 (defn fetch-query-params
   "Prepares the query params for fetching cards."
-  [{::kws/keys [page page-size include-tags exclude-tags tags-filter-query]}]
-  (cond-> {:page (or page default-page) :pageSize (or page-size default-page-size)}
-    include-tags      (assoc :tags (http.utils/list->query-arg include-tags))
-    exclude-tags      (assoc :tagsNot (http.utils/list->query-arg exclude-tags))
-    tags-filter-query (assoc :query tags-filter-query)))
+  [{config kws/config}]
+  (let [page              (kws.config/page config)
+        page-size         (kws.config/page-size config)
+        include-tags      (kws.config/include-tags config)
+        exclude-tags      (kws.config/exclude-tags config)
+        tags-filter-query (kws.config/tags-filter-query config)]
+    (cond-> {:page (or page default-page) :pageSize (or page-size default-page-size)}
+      include-tags      (assoc :tags (http.utils/list->query-arg include-tags))
+      exclude-tags      (assoc :tagsNot (http.utils/list->query-arg exclude-tags))
+      tags-filter-query (assoc :query tags-filter-query))))
 
 (defn- parse-fetch-response
   [{::kws.http/keys [success? body]}]

--- a/src/ohmycards/web/views/cards_grid/control_header.cljs
+++ b/src/ohmycards/web/views/cards_grid/control_header.cljs
@@ -1,8 +1,9 @@
 (ns ohmycards.web.views.cards-grid.control-header
-  (:require [ohmycards.web.utils.pagination :as utils.pagination]
-            [ohmycards.web.icons :as icons]
+  (:require [ohmycards.web.icons :as icons]
+            [ohmycards.web.kws.cards-grid.config.core :as kws.config]
             [ohmycards.web.kws.views.cards-grid.core :as kws]
             [ohmycards.web.utils.components :as utils.components]
+            [ohmycards.web.utils.pagination :as utils.pagination]
             [ohmycards.web.views.cards-grid.state-management :as state-management]))
 
 (defn- arrow-left [props]
@@ -31,7 +32,8 @@
 (defn- header-center
   "The center of the header, containing the pagination controls."
   [{:keys [state] ::kws/keys [] :as props}]
-  (let [{::kws/keys [page page-size count-of-cards]} @state]
+  (let [{config kws/config count-of-cards kws/count-of-cards} @state
+        {page kws.config/page page-size kws.config/page-size} config]
     [:span.cards-grid-header__center
      [arrow-left props]
      [page-counter {::page page ::max-page (utils.pagination/last-page page-size count-of-cards)}]

--- a/test/ohmycards/web/views/cards_grid/control_header_test.cljs
+++ b/test/ohmycards/web/views/cards_grid/control_header_test.cljs
@@ -1,8 +1,9 @@
 (ns ohmycards.web.views.cards-grid.control-header-test
-  (:require [ohmycards.web.views.cards-grid.control-header :as sut]
-            [cljs.test :refer-macros [is are deftest testing use-fixtures async]]
+  (:require [cljs.test :refer-macros [are async deftest is testing use-fixtures]]
+            [ohmycards.web.kws.cards-grid.config.core :as kws.config]
             [ohmycards.web.kws.views.cards-grid.core :as kws]
-            [ohmycards.web.test-utils :as tu]))
+            [ohmycards.web.test-utils :as tu]
+            [ohmycards.web.views.cards-grid.control-header :as sut]))
 
 (deftest test-page-counter
   (is (= [:span.small-box "2 | 3"]
@@ -20,7 +21,8 @@
      (some
       #(= [sut/page-counter {::sut/page 2 ::sut/max-page 2}] %)
       (sut/header-center
-       {:state (atom {kws/page 2 kws/count-of-cards 2 kws/page-size 1})})))))
+       {:state (atom {kws/config {kws.config/page 2 kws.config/page-size 1}
+                      kws/count-of-cards 2})})))))
 
 (deftest test-main
 

--- a/test/ohmycards/web/views/cards_grid/state_management_test.cljs
+++ b/test/ohmycards/web/views/cards_grid/state_management_test.cljs
@@ -10,7 +10,9 @@
 
   (testing "On Success"
 
-    (let [state {::foo 1 kws.cards-grid/error-message nil}
+    (let [state {::foo 1
+                 kws.cards-grid/error-message nil
+                 kws.cards-grid/config {kws.config/tags-filter-query "(FOO)"}}
           fetch-res {kws.fetch-cards/cards [{:id "1" :title "FOO" :body "foo bar baz"}]
                      kws.fetch-cards/page 2
                      kws.fetch-cards/page-size 10}
@@ -27,56 +29,48 @@
         (is (= kws.cards-grid/status-ready (kws.cards-grid/status new-state))))
 
       (testing "Sets the current page"
-        (is (= 2 (kws.cards-grid/page new-state))))
+        (is (= 2 (-> new-state kws.cards-grid/config kws.config/page))))
 
       (testing "Sets the current page size"
-        (is (= 10 (kws.cards-grid/page-size new-state)))))))
+        (is (= 10 (-> new-state kws.cards-grid/config kws.config/page-size))))
+
+      (testing "Preserves old config"
+        (is (= "(FOO)" (-> new-state kws.cards-grid/config kws.config/tags-filter-query)))))))
 
 (deftest test-has-next-page?
-  (is (true? (sut/has-next-page? {::kws.cards-grid/count-of-cards 10
-                                  ::kws.cards-grid/page 4
-                                  ::kws.cards-grid/page-size 2})))
-  (is (false? (sut/has-next-page? {::kws.cards-grid/count-of-cards 10
-                                   ::kws.cards-grid/page 5
-                                   ::kws.cards-grid/page-size 2})))
-  (is (true? (sut/has-next-page? {::kws.cards-grid/count-of-cards 11
-                                   ::kws.cards-grid/page 5
-                                  ::kws.cards-grid/page-size 2}))))
+  (is (true? (sut/has-next-page? {kws.cards-grid/count-of-cards 10
+                                  kws.cards-grid/config {kws.config/page 4
+                                                         kws.config/page-size 2}})))
+  (is (false? (sut/has-next-page? {kws.cards-grid/count-of-cards 10
+                                   kws.cards-grid/config {kws.config/page 5
+                                                          kws.config/page-size 2}})))
+  (is (true? (sut/has-next-page? {kws.cards-grid/count-of-cards 11
+                                  kws.cards-grid/config {kws.config/page 5
+                                                         kws.config/page-size 2}}))))
 
 (deftest test-set-config-profile
-  (let [profile {kws.profile/name "FOO"
-                 kws.profile/config {kws.config/exclude-tags ["A"]
-                                     kws.config/include-tags ["B"]
-                                     kws.config/page 1
-                                     kws.config/page-size 2
-                                     kws.config/tags-filter-query "(FOO)"}}]
-    (is (= {kws.cards-grid/exclude-tags ["A"]
-            kws.cards-grid/include-tags ["B"]
-            kws.cards-grid/page 1
-            kws.cards-grid/page-size 2
-            kws.cards-grid/tags-filter-query "(FOO)"}
-           (sut/set-config-profile {} profile)))))
+  (let [config {kws.config/exclude-tags ["A"]
+                kws.config/include-tags ["B"]
+                kws.config/page 1
+                kws.config/page-size 2
+                kws.config/tags-filter-query "(FOO)"}
+        profile {kws.profile/name "FOO"
+                 kws.profile/config config}]
+
+    (is (= {kws.cards-grid/config config} (sut/set-config-profile {} profile)))))
 
 (deftest test-fetch-cards-params
 
-  (let [source-params {kws.cards-grid/page 1
-                       kws.cards-grid/page-size 2
-                       kws.cards-grid/include-tags ["A"]
-                       kws.cards-grid/exclude-tags ["C"]
-                       kws.cards-grid/tags-filter-query "(tags CONTAINS 'foo')"}
-        expected-params {kws.fetch-cards/page 1
-                         kws.fetch-cards/page-size 2
-                         kws.fetch-cards/include-tags ["A"]
-                         kws.fetch-cards/exclude-tags ["C"]
-                         kws.fetch-cards/tags-filter-query "(tags CONTAINS 'foo')"}]
+  (let [config {kws.config/page 1
+                kws.config/page-size 2
+                kws.config/include-tags ["A"]
+                kws.config/exclude-tags ["C"]
+                kws.config/tags-filter-query "(tags CONTAINS 'foo')"}
+        source-params {kws.cards-grid/config config}
+        expected-params {kws.fetch-cards/config config}]
 
     (testing "Base"
-      (is (= expected-params (sut/fetch-cards-params source-params))))
-
-    (testing "Without tags query filter"
-      (let [source-params   (dissoc source-params kws.cards-grid/tags-filter-query)
-            expected-params (dissoc expected-params kws.fetch-cards/tags-filter-query)]
-        (is (= expected-params (sut/fetch-cards-params source-params)))))))
+      (is (= expected-params (sut/fetch-cards-params source-params))))))
 
 (deftest test-state-not-initialized?
 
@@ -89,3 +83,44 @@
 (deftest test-refetch-from-props!
   (with-redefs [sut/refetch! #(do [%1 %2])]
     (is (= [1 2] (sut/refetch-from-props! {:state 1 kws.cards-grid/fetch-cards! 2})))))
+
+(defn gen-props [] {:state (atom {})})
+
+(deftest test-set-page-from-props
+  (testing "Sets page"
+    (with-redefs [sut/refetch! #(do ::res)]
+      (let [props (gen-props)]
+        (is (= ::res (sut/set-page-from-props! props 10)))
+        (is (= 10 (-> props :state deref kws.cards-grid/config kws.config/page)))))))
+
+(deftest test-set-page-size-from-props
+  (testing "Sets page size"
+    (with-redefs [sut/refetch! #(do ::res)]
+      (let [props (gen-props)]
+        (is (= ::res (sut/set-page-size-from-props! props 10)))
+        (is (= 10 (-> props :state deref kws.cards-grid/config kws.config/page-size)))))))
+
+(deftest test-set-include-tags-from-props
+  (testing "Sets include tags"
+    (with-redefs [sut/refetch! #(do ::res)]
+      (let [props (gen-props)]
+        (is (= ::res (sut/set-include-tags-from-props! props ["FOO" ""])))
+        (is (= ["FOO"] (-> props :state deref kws.cards-grid/config kws.config/include-tags)))))))
+
+(deftest test-set-exclude-tags-from-props
+  (testing "Sets exclude tags"
+    (with-redefs [sut/refetch! #(do ::res)]
+      (let [props (gen-props)]
+        (is (= ::res (sut/set-exclude-tags-from-props! props ["FOO" ""])))
+        (is (= ["FOO"] (-> props :state deref kws.cards-grid/config kws.config/exclude-tags)))))))
+
+(deftest test-set-tags-filter-query-from-props
+  (testing "Sets query"
+    (with-redefs [sut/refetch! #(do ::res)]
+      (let [props (gen-props)]
+        (is (= ::res (sut/set-tags-filter-query-from-props! props "(FOO)")))
+        (is (= "(FOO)" (-> props :state deref kws.cards-grid/config kws.config/tags-filter-query)))))))
+
+(deftest has-previous-page?
+  (is (true? (sut/has-previous-page? {kws.cards-grid/config {kws.config/page 2}})))
+  (is (false? (sut/has-previous-page? {kws.cards-grid/config {kws.config/page 1}}))))


### PR DESCRIPTION
Unifies the treatment for cards configuration, removing duplicated
keywords that were used by different systems (like the cards grid, the
cards grid dashboard and the fetch cards) and unifying all usages of
the configs for the single kws namespace with configs