### PR TITLE
NEW Adds about page with versions for FE and BE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ TARGET_CSS_DIR ?= ./public/css
 # Extra options for karma
 KARMA_OPTS ?=
 
+# Config options passed to shadow cljs `--config-merge`.
+SHADOW_CLJS_RELEASE_CONFIG ?= {}
+
 # Install node deps
 install:
 	npm install
@@ -48,7 +51,7 @@ build/%:
 # Releases a specific target
 release/%:
 	$(eval BUILD=$(subst release/,,$@))
-	npx shadow-cljs release $(BUILD)
+	npx shadow-cljs release --config-merge $(SHADOW_CLJS_RELEASE_CONFIG) $(BUILD)
 
 # Test using karma
 test: karma

--- a/devops/Makefile
+++ b/devops/Makefile
@@ -27,6 +27,11 @@ define imgtag_prod
 $(shell echo "vitorqb23/ohmycards-web:$(version)")
 endef
 
+# The shadow-cljs config used for release
+define shadow_cljs_release_config
+'{:closure-defines {ohmycards.web.version/Version "$(version)"}}'
+endef
+
 # Cleans the build directory
 clean:
 	rm -rf $(BUILD_DIR) ./target ./context
@@ -42,7 +47,12 @@ artifacts/prod: build/prod
 	$(call msg,"Preparing to generate artifact $(target_prod) for version $(version)")
 
 	$(call msg,"Compiling scss and js...")
-	$(MAKE) -C $(BUILD_DIR) ci scss/once release/app
+	$(MAKE)\
+          -C $(BUILD_DIR) \
+          ci \
+          scss/once \
+          release/app \
+          SHADOW_CLJS_RELEASE_CONFIG=$(shadow_cljs_release_config)
 
 	$(call msg,"Creating .tar.gz file...")
 	tar --dereference -vzcf $(target_prod) -C $(BUILD_DIR)/public css js vendor index.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -3280,9 +3280,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.10.12.tgz",
-      "integrity": "sha512-LLBzhh7MOzVEIUkd3YOmiaDecXVBybfaHbfHYt5C+1x18gEhZhbi5APBeUWa7e7vmcB16nY6/R5XnKbt8OCelA==",
+      "version": "2.8.94",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.8.94.tgz",
+      "integrity": "sha512-o3ykB9TpCnMGem4cjmbAkVeYe/saGMVl6RhC/BdO1UNlhPZUp3hwdVp9mBDN079O5jJEtC8RmjHY6xe9utYokw==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-cljs-test": "^0.1.0",
     "node-sass": "^4.14.1",
-    "shadow-cljs": "^2.10.12"
+    "shadow-cljs": "2.8.94"
   },
   "dependencies": {
     "@reach/combobox": "^0.10.3",

--- a/src/ohmycards/web/components/spinner/core.cljs
+++ b/src/ohmycards/web/components/spinner/core.cljs
@@ -1,0 +1,10 @@
+(ns ohmycards.web.components.spinner.core)
+
+(defn main
+  "A spinner."
+  [_]
+  [:div.spinner])
+
+(defn small [_] [:div.spinner.spinner--small])
+(defn smaller [_] [:div.spinner.spinner--smaller])
+(defn smallest [_] [:div.spinner.spinner--smallest])

--- a/src/ohmycards/web/core.cljs
+++ b/src/ohmycards/web/core.cljs
@@ -51,6 +51,7 @@
             [ohmycards.web.services.shortcuts-register.core
              :as
              services.shortcuts-register]
+            [ohmycards.web.views.about.core :as views.about]
             [ohmycards.web.views.cards-grid.config-dashboard.core
              :as
              cards-grid.config-dashboard]
@@ -107,6 +108,11 @@
   [views.login/main {:state (state-cursor :views.login)
                      :http-fn http-fn
                      :save-user-fn #(services.login/set-user! %)}])
+
+(defn about
+  "An instance for the about page."
+  []
+  [views.about/main {:http-fn http-fn}])
 
 (defn header
   "An instance for the headerer component."
@@ -168,6 +174,9 @@
   [["/"
     {:name routing.pages/home
      :view #'cards-grid-page}]
+   ["/about"
+    {:name routing.pages/about
+     :view #'about}]
    ["/cards-grid/config"
     {:name routing.pages/cards-grid-config
      :view #'cards-grid-config-page}]
@@ -243,6 +252,10 @@
      kws.hydra/description "New Cards"
      kws.hydra/type        kws.hydra/leaf
      kws.hydra.leaf/value  #(routing.core/goto! routing.pages/new-card)}
+    {kws.hydra/shortcut    \a
+     kws.hydra/description "About the app"
+     kws.hydra/type        kws.hydra/leaf
+     kws.hydra.leaf/value  #(routing.core/goto! routing.pages/about)}
     {kws.hydra/shortcut    \q
      kws.hydra/description "Quit"
      kws.hydra/type        kws.hydra/leaf

--- a/src/ohmycards/web/kws/routing/pages.cljs
+++ b/src/ohmycards/web/kws/routing/pages.cljs
@@ -4,3 +4,4 @@
 (def cards-grid-config "Page for configuration of the cards grid." ::cards-grid-config)
 (def new-card "Page for creating new cards." ::new-card)
 (def edit-card "Page for editting a card." ::edit-card)
+(def about "The page with metadata for the application, including version." ::about)

--- a/src/ohmycards/web/services/fetch_be_version/core.cljs
+++ b/src/ohmycards/web/services/fetch_be_version/core.cljs
@@ -1,0 +1,11 @@
+(ns ohmycards.web.services.fetch-be-version.core
+  (:require [cljs.core.async :as async]
+            [ohmycards.web.kws.http :as kws.http]))
+
+(defn main
+  "Fetches the BE version and returns it as a string."
+  [{:keys [http-fn]}]
+  (async/go
+    (-> (http-fn kws.http/url "/version" kws.http/method :GET)
+        async/<!
+        kws.http/body)))

--- a/src/ohmycards/web/version.cljs
+++ b/src/ohmycards/web/version.cljs
@@ -1,0 +1,5 @@
+(ns ohmycards.web.version)
+
+;; This is supposed to have the current version.
+;; You should define this variable during the build process.
+(goog-define VERSION "dev")

--- a/src/ohmycards/web/views/about/core.cljs
+++ b/src/ohmycards/web/views/about/core.cljs
@@ -1,0 +1,51 @@
+(ns ohmycards.web.views.about.core
+  (:require [cljs.core.async :as async]
+            [ohmycards.web.components.spinner.core :as spinner]
+            [ohmycards.web.services.fetch-be-version.core
+             :as
+             services.fetch-be-version]
+            [ohmycards.web.version :as version]
+            [reagent.core :as r]))
+
+(defn- about-textbox
+  "Main textbox with explanation about OhMyCards."
+  []
+  [:div.about-view__about-textbox
+   [:h2 "About"]
+   [:p (str "OhMyCards is a personal project aimed at being a simple system to keep track of"
+            " cards.")]
+   [:p (str "It was also an opportunity to learn Scala and practice my Clojurescript/React skills")]
+   [:p (str "If you have any questions, see ")
+    [:a {:href "https://github.com/vitorqb/oh-my-cards"}
+     "https://github.com/vitorqb/oh-my-cards"]
+    " and feel free to drop me a line!"]])
+
+(defn- version-label
+  "A label with a version for the app or the server."
+  [{::keys [text version]}]
+  (if version
+    [:div (str text version)]
+    [:div text [spinner/smallest]]))
+
+(defn- versions-infobox
+  "A box with information for the versions."
+  [{::keys [be-version fe-version]}]
+  [:div.about-view__versions-infobox
+   [:h2 "Versions"]
+   [version-label {::text "Server: " ::version be-version}]
+   [version-label {::text "Web: " ::version fe-version}]])
+
+(defn- fetch-be-version!
+  [{:keys [http-fn]} a]
+  "Queries the service to fetch the BE version and set's the atom `a` to it."
+  (async/go (reset! a (async/<! (services.fetch-be-version/main {:http-fn http-fn})))))
+
+(defn main
+  "A page to display information about the system."
+  [props]
+  (let [!be-version (r/atom nil)]
+    (fetch-be-version! props !be-version)
+    (fn [_]
+      [:div.about-view
+       [about-textbox]
+       [versions-infobox {::be-version @!be-version ::fe-version version/VERSION}]])))

--- a/src/scss/_about-view.scss
+++ b/src/scss/_about-view.scss
@@ -1,0 +1,8 @@
+.about-view {
+    padding: 10px 20% 0 20%;
+    max-width: 1200px;
+
+    &__about-textbox {
+        margin-bottom: $margin-biggest;
+    }
+}

--- a/src/scss/_spinner.scss
+++ b/src/scss/_spinner.scss
@@ -1,0 +1,64 @@
+
+.spinner {
+
+    display: inline-block;
+    width: 80px;
+    height: 80px;
+
+    &:after {
+        content: " ";
+        display: block;
+        width: 64px;
+        height: 64px;
+        margin: 8px;
+        border-radius: 50%;
+        border: 6px solid $color-primary;
+        border-color: $color-primary transparent $color-primary transparent;
+        animation: spinner 1.2s linear infinite;
+    }
+
+    &--smallest {
+        width: 20px;
+        height: 20px;
+        &:after {
+            width: 15px;
+            height: 15px;
+            margin: 2px;
+            border: 3px solid;
+            border-color: $color-primary transparent $color-primary transparent;
+        }
+    }
+
+    &--smaller {
+        width: 30px;
+        height: 30px;
+        &:after {
+            width: 20px;
+            height: 20px;
+            margin: 3px;
+            border: 4px solid;
+            border-color: $color-primary transparent $color-primary transparent;
+        }
+    }
+
+    &--small {
+        width: 40px;
+        height: 40px;
+        &:after {
+            width: 25px;
+            height: 25px;
+            margin: 4px;
+            border: 5px solid;
+            border-color: $color-primary transparent $color-primary transparent;
+        }
+    }
+}
+
+@keyframes spinner {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -14,9 +14,14 @@ $color-bad: red;
 $color-good: green;
 
 $color-white: #ecf0f1;
+$color-black: #000;
 
 //
 // Spaces
 //
 $margin-smaller: 5px;
 $margin-small: 10px;
+$margin-normal: 20px;
+$margin-big: 30px;
+$margin-bigger: 45px;
+$margin-biggest: 70px;

--- a/src/scss/site.scss
+++ b/src/scss/site.scss
@@ -20,6 +20,8 @@
 @import "action-dispatcher";
 @import "hydra";
 @import "markdown-input";
+@import "about-view";
+@import "spinner";
 
 body {
   font-family: 'Helvetica Neue', Verdana, Helvetica, Arial, sans-serif;
@@ -31,7 +33,7 @@ body {
 }
 
 h1, h2, h3 {
-  color: #000;
+    color: $color-primary-darker;
 }
 h1 {
   font-size: 2.5em

--- a/src/test_ns_requires.cljs
+++ b/src/test_ns_requires.cljs
@@ -44,6 +44,7 @@
 [ohmycards.web.services.login.utils-test]
 [ohmycards.web.utils.components-test]
 [ohmycards.web.utils.pagination-test]
+[ohmycards.web.views.about.core-test]
 [ohmycards.web.views.cards-grid.config-dashboard.core-test]
 [ohmycards.web.views.cards-grid.config-dashboard.state-management-test]
 [ohmycards.web.views.cards-grid.control-filter-test]

--- a/test/ohmycards/web/views/about/core_test.cljs
+++ b/test/ohmycards/web/views/about/core_test.cljs
@@ -1,0 +1,54 @@
+(ns ohmycards.web.views.about.core-test
+  (:require [cljs.core.async :as async]
+            [cljs.test :refer-macros [are async deftest is testing use-fixtures]]
+            [ohmycards.web.components.spinner.core :as spinner]
+            [ohmycards.web.services.fetch-be-version.core
+             :as
+             services.fetch-be-version]
+            [ohmycards.web.test-utils :as tu]
+            [ohmycards.web.views.about.core :as sut]))
+
+(deftest test-main
+  (testing "Renders the about-textbox"
+    (with-redefs [sut/fetch-be-version! #(do)]
+      (is
+       (tu/exists-in-component?
+        [sut/about-textbox]
+        (tu/comp-seq ((sut/main {}))))))))
+
+(deftest test-fetch-be-version!
+  (async
+   done
+   (async/go
+     (with-redefs [services.fetch-be-version/main #(async/go "FOO")]
+      (let [a (atom nil)]
+        (async/<! (sut/fetch-be-version! {:http-fn #(do)} a))
+        (is (= @a "FOO"))
+        (done))))))
+
+(deftest test-version-label
+
+  (testing "With version"
+    (is (= [:div "FOO: bar"]
+           (sut/version-label {::sut/text "FOO: " ::sut/version "bar"}))))
+
+  (testing "Without version"
+    (is (= [:div "FOO: " [spinner/smallest]]
+           (sut/version-label {::sut/text "FOO: " ::sut/version nil})))))
+
+(deftest test-versions-infobox
+  (let [be-version "2.2"
+        fe-version "1.1"
+        comp-seq   (tu/comp-seq
+                    (sut/versions-infobox
+                     {::sut/be-version be-version ::sut/fe-version fe-version}))]
+
+    (testing "Renders BE version"
+      (is (tu/exists-in-component?
+           [sut/version-label {::sut/text "Server: " ::sut/version be-version}]
+           comp-seq)))
+
+    (testing "Renders FE version"
+      (is (tu/exists-in-component?
+           [sut/version-label {::sut/text "Web: " ::sut/version fe-version}]
+           comp-seq)))))


### PR DESCRIPTION
- Adds a new page/url "about", that has a small text to describe the
system and a paragraph with the FE and BE versions.

- The FE version is injected during build using google
define (https://shadow-cljs.github.io/docs/UsersGuide.html#closure-defines).

- The BE version is fetched from an url.

- The shadow-cljs version was downgraded until the latest version
without a bug preventing running the tests.

- Adds spinner while we are fetching from the BE.