### PR TITLE
FIX Thunkify props definition so the components react to state changes

### DIFF
--- a/src/ohmycards/web/core.cljs
+++ b/src/ohmycards/web/core.cljs
@@ -125,7 +125,8 @@
   []
   [controllers.cards-grid/cards-grid])
 
-(def new-card-page-props
+(defn new-card-page-props
+  []
   {:http-fn http-fn
    :state (state-cursor :views.new-card)
    kws.new-card/goto-home! #(routing.core/goto! routing.pages/home)
@@ -134,10 +135,11 @@
 (defn new-card-page
   "An instance for the new-card view."
   []
-  [new-card/main new-card-page-props])
+  [new-card/main (new-card-page-props)])
 
-(def edit-card-page-props
+(defn edit-card-page-props
   "Props for the `edit-card-page`."
+  []
   {kws.edit-card/goto-home! #(routing.core/goto! routing.pages/home)
    kws.edit-card/fetch-card! #(services.cards-crud/read! {:http-fn http-fn} %)
    kws.edit-card/cards-metadata (lenses.metadata/cards @state)
@@ -147,7 +149,7 @@
 (defn edit-card-page
   "An instance for the edit-card view"
   []
-  [edit-card/main edit-card-page-props])
+  [edit-card/main (edit-card-page-props)])
 
 (defn cards-grid-config-page
   "An instance for the cards-grid-config view."
@@ -240,10 +242,10 @@
     (condp = current-route-name
 
       routing.pages/edit-card
-      (edit-card.handlers/hydra-head edit-card-page-props)
+      (edit-card.handlers/hydra-head (edit-card-page-props))
 
       routing.pages/new-card
-      (new-card/hydra-head new-card-page-props)
+      (new-card/hydra-head (new-card-page-props))
 
       nil)))
 

--- a/test/ohmycards/web/core_test.cljs
+++ b/test/ohmycards/web/core_test.cljs
@@ -11,7 +11,8 @@
             [ohmycards.web.kws.lenses.routing :as lenses.routing]
             [ohmycards.web.kws.routing.pages :as routing.pages]
             [ohmycards.web.test-utils :as tu]
-            [ohmycards.web.views.edit-card.handlers :as edit-card.handlers]))
+            [ohmycards.web.views.edit-card.handlers :as edit-card.handlers]
+            [reagent.core :as r]))
 
 (deftest test-current-view*
 
@@ -39,7 +40,7 @@
 
 (deftest test-contextual-actions-dispatcher-hydra-head!
 
-  (letfn [(gen-state [route-name] (atom {lenses.routing/match {:data {:name route-name}}}))]
+  (letfn [(gen-state [route-name] (r/atom {lenses.routing/match {:data {:name route-name}}}))]
 
     (testing "Nil for no route"
       (with-redefs [sut/state (atom nil)]


### PR DESCRIPTION
Because we declared high level props with `def` that were
dereferencing the `state`, the component instances would not deref the
state themselves, therefore they would not react to state changes.