### PR TITLE
FIX _21 Returns to page 1 after filtering and dont repeat if not needed

### DIFF
--- a/src/ohmycards/web/views/cards_grid/state_management.cljs
+++ b/src/ohmycards/web/views/cards_grid/state_management.cljs
@@ -101,10 +101,14 @@
 
 (defn commit-search!
   [{:keys [state] :as props}]
-  (let [search-term (kws.cards-grid/filter-input-search-term @state)]
-    (log (str "Committing search to " search-term "..."))
-    (swap! state assoc kws.cards-grid/search-term search-term)
-    (refetch-from-props! props)))
+  (let [new-search-term (kws.cards-grid/filter-input-search-term @state)
+        old-search-term (some-> @state kws.cards-grid/search-term)]
+    (when-not (= new-search-term old-search-term)
+      (log (str "Committing search to " new-search-term "..."))
+      (swap! state #(-> %
+                        (assoc kws.cards-grid/search-term new-search-term)
+                        (assoc-in [kws.cards-grid/config kws.config/page] 1)))
+      (refetch-from-props! props))))
 
 (defn set-page-from-props!
   "Set's page on the state"

--- a/test/ohmycards/web/views/cards_grid/state_management_test.cljs
+++ b/test/ohmycards/web/views/cards_grid/state_management_test.cljs
@@ -125,15 +125,32 @@
 (deftest test-commit-search!
 
   (with-redefs [sut/refetch-from-props! #(do [::result %1])]
-    (let [state  (atom {kws.cards-grid/filter-input-search-term "FOO"})
-          props  {:state state}
-          result (sut/commit-search! props)]
 
-      (testing "Set's the committed search-term from the input search term"
-        (is (= "FOO" (kws.cards-grid/search-term @state))))
+    (testing "When called..."
+      
+      (let [state  (atom {kws.cards-grid/filter-input-search-term "FOO"})
+            props  {:state state}
+            result (sut/commit-search! props)]
 
-      (testing "Refetches the grid"
-        (is (= result [::result props]))))))
+        (testing "Set's the committed search-term from the input search term"
+          (is (= "FOO" (kws.cards-grid/search-term @state))))
+
+        (testing "Set's page back to 1"
+          (is (= 1 (-> @state kws.cards-grid/config kws.config/page))))
+
+        (testing "Refetches the grid"
+          (is (= result [::result props])))))
+
+    (testing "Don't do anything if search term has not changed"
+      
+      (let [state  {kws.cards-grid/filter-input-search-term "FOO"
+                    kws.cards-grid/search-term "FOO"}
+            state' (atom state)
+            props  {:state state'}
+            result (sut/commit-search! props)]
+
+        (is (= state @state'))
+        (is (nil? result))))))
 
 (defn gen-props [] {:state (atom {})})
 


### PR DESCRIPTION
- Make sure the grid goes back to page 1 after a filter term is
committed

- Don't run the search if the search input has not changed