### PR TITLE
NEW _59 Transforms grid-profile into global parameter

### DIFF
--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -11,19 +11,23 @@
                 [refactor-nrepl "2.5.0"]
                 [medley "1.3.0"]]
 
- :builds {:app  {:target     :browser
-                 :output-dir "public/js"
-                 :asset-path "/js"
-                 :modules    {:app {:entries [ohmycards.web.core]}}
-                 :devtools   {:after-load ohmycards.web.core/mount-root
-                              :preloads [pjstadig.humane-test-output
-                                         dev.core]
-                              :repl-init-ns dev.core
-                              :repl-pprint true}}
+ :builds {:app {:target     :browser
+                :output-dir "public/js"
+                :asset-path "/js"
+                :modules    {:app {:entries [ohmycards.web.core]}}
+                :devtools   {:after-load   ohmycards.web.core/mount-root
+                             :preloads     [pjstadig.humane-test-output
+                                            dev.core]
+                             :repl-init-ns dev.core
+                             :repl-pprint  true}
+                :dev        {;; This allows us to use with-redefs for multi arit fns
+                             ;; see https://clojure.atlassian.net/browse/CLJS-1623
+                             :compiler-options {:static-fns false}}}
 
-          :test {:target     :karma
-                 :output-to  "target/test.js"
-                 :ns-regexp  "-test$"}}
+          :test {:target           :karma
+                 :output-to        "target/test.js"
+                 :ns-regexp        "-test$"
+                 :compiler-options {:static-fns false}}}
 
  :nrepl {:middleware [refactor-nrepl.middleware/wrap-refactor]}
  

--- a/src/ohmycards/web/kws/services/cards_grid_profile_manager/core.cljs
+++ b/src/ohmycards/web/kws/services/cards_grid_profile_manager/core.cljs
@@ -1,5 +1,11 @@
 (ns ohmycards.web.kws.services.cards-grid-profile-manager.core)
 
+;; Profile Response attrs
 (def success? "Was the service fetch successfull?" ::success?)
 (def fetched-profile "The fetched profile." ::fetched-profile)
-(def on-metadata-fetch "A function called when a new metadata is fetched" ::on-metadata-fetch)
+
+;; Configuration
+(def set-metadata-fn! "A function called when a new metadata is fetched" ::set-metadata-fn!)
+
+;; Bus actions
+(def action-new-grid-profile "A event bus action for a new grid profile fetched." ::action-new-grid-profile)

--- a/src/ohmycards/web/kws/services/routing/core.cljs
+++ b/src/ohmycards/web/kws/services/routing/core.cljs
@@ -13,6 +13,7 @@
 
 ;; Params and Options
 (def query-params "Query parameters for routing." ::query-params)
+(def global-query-params "A set with global query parameters, kept between routings." ::global-query-params)
 
 ;; Bus Events/Actions
 (def action-navigated-to-route "An action representing that the app navigated to a route."

--- a/src/ohmycards/web/services/cards_grid_profile_manager/route_sync.cljs
+++ b/src/ohmycards/web/services/cards_grid_profile_manager/route_sync.cljs
@@ -1,0 +1,68 @@
+(ns ohmycards.web.services.cards-grid-profile-manager.route-sync
+  "Module responsible for synchronizing the profile with the current route params."
+  (:require [cljs.core.async :as a]
+            [ohmycards.web.kws.services.cards-grid-profile-manager.core :as kws]
+            [ohmycards.web.services.cards-grid-profile-manager.core :as core]
+            [ohmycards.web.services.events-bus.core :as events-bus]
+            [ohmycards.web.services.routing.core :as services.routing]
+            [ohmycards.web.utils.logging :as logging]))
+
+(logging/deflogger log "Services.CardsGridProfileLoader.RouteSync")
+
+(defonce ^:private current-profile (atom nil))
+
+;; Helpers
+(defn- load!
+  "Returns a channel with a fetch profile response for a given name."
+  [profile-name]
+  (if (nil? profile-name)
+    (a/go {kws/success? true kws/fetched-profile nil})
+    (core/load! profile-name)))
+
+(defn- load-from-route-change!
+  "Loads a profile from a change on the url."
+  [old-match new-match]
+  (let [new-profile-name (some-> new-match :query-params :grid-profile)
+        old-profile-name (some-> old-match :query-params :grid-profile)]
+    (when (not= new-profile-name old-profile-name)
+      (load! new-profile-name))))
+
+(defn- handle-success!
+  "Handles a new profile successfully fetched."
+  [response]
+  (let [new-profile (kws/fetched-profile response)]
+    (reset! current-profile new-profile)
+    (events-bus/send! kws/action-new-grid-profile new-profile)))
+
+(defn- handle-error!
+  "Handles a failed new profile fetch."
+  [response]
+  (reset! current-profile nil)
+  (events-bus/send! kws/action-new-grid-profile nil))
+
+(defn- handle-response!
+  "Handles a fetch response"
+  [response]
+  (if (kws/success? response)
+    (handle-success! response)
+    (handle-error! response)))
+
+;; API
+(defn react-to-route-change!
+  "Reacts to a route change by refetching the profile and sending a msg
+  through the bus if needed."
+  [old-match new-match]
+  (when-let [response-chan (load-from-route-change! old-match new-match)]
+    (log "Loading from route change...")
+    (a/go (handle-response! (a/<! response-chan)))))
+
+(defn load-from-route!
+  "Loads a profile from a route match"
+  [match]
+  (log "Loading from route...")
+  (a/go (-> match :query-params :grid-profile load! a/<! handle-response!)))
+
+(defn set-in-route!
+  "Set's a profile name in the route, causing a loading."
+  [profile-name]
+  (services.routing/update-query-params! {:grid-profile profile-name}))

--- a/src/ohmycards/web/services/routing/core.cljs
+++ b/src/ohmycards/web/services/routing/core.cljs
@@ -13,6 +13,7 @@
 ;;
 (defonce ^:private ^:dynamic *state* nil)
 (defonce ^:private ^:dynamic *router* nil)
+(defonce ^:private ^:dynamic *opts* nil)
 
 ;;
 ;; Helpers
@@ -22,7 +23,33 @@
     (log (str "Running hook " h " for match ") m)
     (hook m)))
 
-(defn- run-view-hooks!
+(defn- do-route!
+  "Performs the routing logic, as expected by `rfe/start!`
+  This first argument must be the routing state, and the second the new match."
+  [routing-state match]
+  (log "Routing..." {:routing-state routing-state :match match})
+  (let [old-match @routing-state]
+    (reset! routing-state match)
+    (events-bus/send! kws/action-navigated-to-route [old-match match])))
+
+(defn- new-query-params
+  "Calculates the new query params given the current match, service
+  options and the params to update"
+  [current-match opts new-params-map]
+  (let [current (:query-params current-match)
+        global (kws/global-query-params opts)]
+    (merge (select-keys current global) new-params-map)))
+
+;;
+;; Public API
+;; 
+(defn goto!
+  "Navigates to a route."
+  [k & {::kws/keys [query-params]}]
+  (log "Navigating to" k query-params)
+  (rfe/push-state k {} (new-query-params @*state* *opts* query-params)))
+
+(defn run-view-hooks!
   "Runs view hooks for `enter`, `update` or `leave`.
   Those are functions that are called to perform any initialization/cleanup logic the views
   may need."
@@ -34,37 +61,31 @@
       (run-hook! kws/exit-hook old-match)
       (run-hook! kws/enter-hook new-match))))
 
-(defn- do-route!
-  "Performs the routing logic, as expected by `rfe/start!`
-  This first argument must be the routing state, and the second the new match."
-  [routing-state match]
-  (log "Routing stated!" {:routing-state routing-state :match match})
-  (let [old-match @routing-state]
-    (run-view-hooks! old-match match))
-  (reset! routing-state match)
-  (events-bus/send! kws/action-navigated-to-route match))
-
-;;
-;; Public API
-;; 
-(defn goto!
-  "Navigates to a route."
-  [k & {::kws/keys [query-params]}]
-  (log "Navigating to" k query-params)
-  (rfe/push-state k {} query-params))
+(defn update-query-params!
+  "Updates the query parameters, without changing the route.
+  Each key value pair in `m` will be merged to the query params."
+  [m]
+  (let [current-match @*state*
+        current-route-name (-> current-match :data kws/name)
+        current-query-params (:query-params current-match)]
+    (goto! current-route-name kws/query-params (merge current-query-params m))))
 
 (defn start-routing!
   "Starts the routing with reitit.
   - `raw-routes` Must be a reitit-like route registration data.
-  - `routing-state` An atom-like thing where to store state is stored."
-  [raw-routes routing-state]
-  (log "Starting with" raw-routes routing-state)
-  (set! *state* routing-state)
-  (set! *router* (rf/router raw-routes))
-  (rfe/start!
-   *router*
-   (fn [match _] (do-route! *state* match))
-   {:use-fragment true}))
+  - `routing-state` An atom-like thing where to store state is stored.
+  Available `opts` are:
+  - `global-query-params` A set of global query-params that are kept between all routings."
+  ([raw-routes routing-state] (start-routing! raw-routes routing-state nil))
+  ([raw-routes routing-state opts]
+   (log "Starting with" raw-routes routing-state)
+   (set! *state* routing-state)
+   (set! *router* (rf/router raw-routes))
+   (set! *opts* opts)
+   (rfe/start!
+    *router*
+    (fn [match _] (do-route! *state* match))
+    {:use-fragment true})))
 
 (defn force-update!
   "Forcely runs the `update` hook for the current match. This can be useful, for example,
@@ -80,8 +101,8 @@
   ([view-name opts]
    (path-to! view-name opts *router*))
   
-  ([view-name opts router]
-   (let [match (r/match-by-name router view-name (:path-params opts))
-         path (r/match->path match (:query-params opts))
+  ([view-name {:keys [query-params path-params]} router]
+   (let [match (r/match-by-name router view-name path-params)
+         path (r/match->path match (new-query-params @*state* *opts* query-params))
          path-with-hash (str "/#" path)]
      path-with-hash)))

--- a/src/ohmycards/web/views/cards_grid/config_dashboard/state_management.cljs
+++ b/src/ohmycards/web/views/cards_grid/config_dashboard/state_management.cljs
@@ -21,13 +21,10 @@
                            (into {}))]
     (assoc state kws/config parsed-config)))
 
-(defn set-config-from-loader!
-  "Set's a config from a `services.cards-grid-config-loader` fetch response."
-  [state {::kws.cards-grid-profile-manager/keys [success? fetched-profile] :as fetched}]
-  (log "Resetting config from loader:" fetched)
-  (if success?
-    (swap! state reset-config (kws.profile/config fetched-profile))
-    (log "FAILED: fetch was not successfull")))
+(defn set-profile!
+  "Set's a new grid profile."
+  [props new-profile]
+  (swap! (:state props) reset-config (kws.profile/config new-profile)))
 
 (defn init-state
   "Reducer that initializes the state for the config dashboard."

--- a/src/ohmycards/web/views/cards_grid/core.cljs
+++ b/src/ohmycards/web/views/cards_grid/core.cljs
@@ -62,7 +62,7 @@
    [tags-displayer {::tags tags}]
    [card-display-footer props]])
 
-(defn- main*
+(defn main
   "Rendering logic for the `main` component."
   [{:keys [state] :as props}]
   [loading-wrapper/main {:loading? (state-management/loading? props)}
@@ -78,9 +78,3 @@
         [card-display (assoc props ::card card)])
       [:div.cards-grid__empty-msgbox
        [:div "Nothing to display. Create your first card to get started!"]])]])
-
-(defn main
-  "A view for a grid of cards."
-  [{:keys [state] :as props}]
-  (state-management/initialize-from-props! props)
-  (fn [props] (main* props)))

--- a/src/ohmycards/web/views/cards_grid/state_management.cljs
+++ b/src/ohmycards/web/views/cards_grid/state_management.cljs
@@ -14,11 +14,6 @@
 (logging/deflogger log "Views.CardsGrid.StateManagement")
 
 ;; Helpers
-(defn- state-initialized?
-  "Returns a boolean indicating whether the state has been initialized."
-  [{::kws.cards-grid/keys [status]}]
-  (-> status nil? not))
-
 (defn- reduce-before-fetch-cards
   "Reduces the state before fetching the cards."
   [state]
@@ -76,15 +71,6 @@
   (assoc state kws.cards-grid/config config))
 
 ;; API
-(def init-state! refetch!)
-
-(defn initialize-from-props!
-  "Initializes the component's state."
-  [{:keys [state] ::kws.cards-grid/keys [fetch-cards!]}]
-  (log "Initilizing state...")
-  (when (not (state-initialized? @state))
-    (init-state! state fetch-cards!)))
-
 (defn refetch-from-props!
   "Refetches the cards data using the props."
   [{:keys [state] ::kws.cards-grid/keys [fetch-cards!]}]
@@ -143,16 +129,11 @@
   (swap! state assoc-in [kws.cards-grid/config kws.config/tags-filter-query] new-tags-filter-query)
   (refetch! state fetch-cards!))
 
-(defn set-config-from-loader!
-  "Set's the entire config from the response of `services.cards-grid-profile-manager`"
-  [{:keys [state] ::kws.cards-grid/keys [fetch-cards!]}
-   {::kws.cards-grid-profile-manager/keys [fetched-profile success?] :as loader-response}]
-  (log "Setting config from loader response:" loader-response)
-  (if success?
-    (do
-      (swap! state set-config-profile fetched-profile)
-      (refetch! state fetch-cards!))
-    (log "NOT SET BECAUSE FAILED RESPONSE")))
+(defn set-profile!
+  "Set's a new grid profile."
+  [{:keys [state] ::kws.cards-grid/keys [fetch-cards!]} new-profile]
+  (swap! state set-config-profile new-profile)
+  (refetch! state fetch-cards!))
 
 (defn goto-previous-page!
   "Navigates to the previous page."

--- a/src/test_ns_requires.cljs
+++ b/src/test_ns_requires.cljs
@@ -33,6 +33,7 @@
 [ohmycards.web.services.cards-grid-profile-manager.impl.helpers-test]
 [ohmycards.web.services.cards-grid-profile-manager.impl.read-test]
 [ohmycards.web.services.cards-grid-profile-manager.impl.update-test]
+[ohmycards.web.services.cards-grid-profile-manager.route-sync-test]
 [ohmycards.web.services.cards-metadata-fetcher.core-test]
 [ohmycards.web.services.events-bus.core-test]
 [ohmycards.web.services.fetch-cards.core-test]

--- a/test/ohmycards/web/controllers/cards_grid/core_test.cljs
+++ b/test/ohmycards/web/controllers/cards_grid/core_test.cljs
@@ -22,30 +22,3 @@
       (sut/init-config-dashboard-state! app-state)
       (is (= exp-bind sut/*config-dashboard-state*))
       (is (= exp-state @sut/*config-dashboard-state*)))))
-
-(deftest test-load-profile-from-route-match!
-
-  (let [route-match {:query-params {:grid-profile "FOO" :bar "Bar"}
-                     :data {kws.routing/name ::name}}]
-
-    (testing "Don't do anything if no profile name on the route"
-      (let [route-match (assoc-in route-match [:query-params :grid-profile] nil)
-            calls (atom [])]
-        (with-redefs [sut/load-profile! #(swap! calls conj [::load-profile %1])
-                      routing.core/goto! #(swap! calls conj [::goto %1 %2])]
-          (is (nil? (sut/load-profile-from-route-match! route-match)))
-          (is (= @calls [])))))
-
-    (testing "When there is a route match..."
-      (let [calls (atom [])]
-        (with-redefs [sut/load-profile! #(swap! calls conj [::load-profile %1])
-                      routing.core/goto! #(swap! calls conj [::goto %1 %&])]
-          (let [response (sut/load-profile-from-route-match! route-match)]
-
-            (testing "calls load-profile with the profile name"
-              (is (= [::load-profile "FOO"] (@calls 0))))
-
-            (testing "calls routing goto with a new query-params without grid-profile"
-              (let [exp-query-params {:bar "Bar"}]
-                (is (= [::goto ::name [kws.routing/query-params exp-query-params]]
-                       (@calls 1)))))))))))

--- a/test/ohmycards/web/services/cards_grid_profile_manager/core_test.cljs
+++ b/test/ohmycards/web/services/cards_grid_profile_manager/core_test.cljs
@@ -6,6 +6,7 @@
             [ohmycards.web.kws.cards-grid.profile.core :as kws.profile]
             [ohmycards.web.kws.http :as kws.http]
             [ohmycards.web.kws.services.cards-grid-profile-manager.core :as kws]
+            [ohmycards.web.kws.services.events-bus.core :as events-bus]
             [ohmycards.web.services.cards-grid-profile-manager.core :as sut]
             [ohmycards.web.services.cards-grid-profile-manager.impl.fetch-metadata
              :as
@@ -15,8 +16,8 @@
   (let [fetch-response {kws.http/body {:names ["FOO" "BAR"]}}
         parsed-response (fetch-metadata/parse-response fetch-response)
         do-fetch-metadata! #(a/go parsed-response)
-        on-metadata-fetch #(assoc % ::foo 1)
-        opts {kws/on-metadata-fetch on-metadata-fetch}
+        set-metadata-fn! #(assoc % ::foo 1)
+        opts {kws/set-metadata-fn! set-metadata-fn!}
         response-chan (sut/fetch-metadata!* opts do-fetch-metadata!)]
     (async done
            (a/go

--- a/test/ohmycards/web/services/cards_grid_profile_manager/route_sync_test.cljs
+++ b/test/ohmycards/web/services/cards_grid_profile_manager/route_sync_test.cljs
@@ -1,0 +1,82 @@
+(ns ohmycards.web.services.cards-grid-profile-manager.route-sync-test
+  (:require [cljs.test :refer-macros [are async deftest is testing use-fixtures]]
+            [ohmycards.web.kws.services.cards-grid-profile-manager.core :as kws]
+            [ohmycards.web.services.cards-grid-profile-manager.core :as core]
+            [ohmycards.web.services.cards-grid-profile-manager.route-sync :as sut]
+            [ohmycards.web.services.events-bus.core :as events-bus]
+            [ohmycards.web.services.routing.core :as services.routing]))
+
+(deftest test-handle-success
+
+  (let [log-calls (atom [])
+        current-profile (atom nil)
+        send-calls (atom [])
+        response {kws/success? true kws/fetched-profile {:id 1}}]
+
+    (with-redefs [sut/log #(swap! log-calls conj %&)
+                  sut/current-profile current-profile
+                  events-bus/send! #(swap! send-calls conj %&)]
+
+      (sut/handle-success! response)
+
+      (testing "Set's current-profile"
+        (is (= @current-profile {:id 1})))
+
+      (testing "Sends msg to bus"
+        (is (= [kws/action-new-grid-profile {:id 1}]))))))
+
+(deftest test-handle-error
+
+  (let [log-calls (atom [])
+        current-profile (atom nil)
+        send-calls (atom [])
+        response {kws/success? true kws/fetched-profile {:id 1}}]
+
+    (with-redefs [sut/log #(swap! log-calls conj %&)
+                  sut/current-profile current-profile
+                  events-bus/send! #(swap! send-calls conj %&)]
+
+      (sut/handle-error! response)
+
+      (testing "Set's current-profile to nil"
+        (is (= @current-profile nil)))
+
+      (testing "Sends msg to bus"
+        (is (= [kws/action-new-grid-profile nil]))))))
+
+
+(deftest test-load-from-route-change
+
+  (testing "When there is no profile on the route => loads with nil"
+    (let [load-calls (atom [])]
+      (with-redefs [sut/load! #(swap! load-calls conj %&)]
+        (let [old-match {:query-params {:grid-profile "FOO"}}
+              new-match {:query-params {:grid-profile nil}}]
+          (sut/load-from-route-change! old-match new-match)
+          (is (= [[nil]] @load-calls))))))
+
+  (testing "When the profile hasn't changed, do nothing"
+    (let [load-calls (atom [])]
+      (with-redefs [sut/load! #(swap! load-calls conj %&)]
+        (let [old-match {:query-params {:grid-profile "FOO"}}
+              new-match {:query-params {:grid-profile "FOO"}}]
+          (sut/load-from-route-change! old-match new-match)
+          (is (= [] @load-calls))))))
+
+  (testing "When the profile has changed, loads and return"
+    (let [load-calls (atom [])]
+      (with-redefs [sut/load! #(do (swap! load-calls conj %&)
+                                   ::result)]
+        (let [old-match {:query-params {:grid-profile "FOO"}}
+              new-match {:query-params {:grid-profile "BAR"}}
+              result    (sut/load-from-route-change! old-match new-match)]
+          (is (= ::result result))
+          (is (= [["BAR"]] @load-calls)))))))
+
+(deftest test-set-in-route!
+
+  (testing "Update grid-profile in query params"
+    (let [args (atom [])]
+      (with-redefs [services.routing/update-query-params! #(swap! args conj %&)]
+        (sut/set-in-route! "name")
+        (is (= [[{:grid-profile "name"}]] @args))))))

--- a/test/ohmycards/web/services/routing/core_test.cljs
+++ b/test/ohmycards/web/services/routing/core_test.cljs
@@ -26,17 +26,43 @@
 
       (testing "Sends event to the bus"
         (with-redefs [event-bus/send! #(do [::send! %1 %2])]
-          (is (= [::send! kws/action-navigated-to-route match]
-                 (sut/do-route! (atom nil) match)))))
+          (is (= [::send! kws/action-navigated-to-route [nil match]]
+                 (sut/do-route! (atom nil) match))))))))
 
-      (testing "Calls run-view-hooks!"
-        (let [args (atom nil)
-              old-match {:name ::old-match}
-              routing-state (atom old-match)]
-          (with-redefs [sut/run-view-hooks! #(reset! args %&)]
-            (sut/do-route! routing-state match)
-            (is (= [old-match match] @args))))))))
+(deftest test-new-query-params
 
+  (testing "Updates keeping from `global` and adding `update`"
+    (let [current-match {:query-params {:foo 1 :bar 2}}
+          opts {kws/global-query-params #{:foo}}
+          new-params-map {:bar 3 :baz 4}]
+      (is (= {:foo 1 :bar 3 :baz 4}
+             (sut/new-query-params current-match opts new-params-map)))))
+
+  (testing "Remove all if not global and no update"
+    (let [current-match {:query-params {:foo 1 :bar 2}}
+          opts {kws/global-query-params #{}}
+          new-params-map {}]
+      (is (= {} (sut/new-query-params current-match opts new-params-map)))))
+
+  (testing "Keep only global"
+    (let [current-match {:query-params {:foo 1 :bar 2}}
+          opts {kws/global-query-params #{:bar}}
+          new-params-map {}]
+      (is (= {:bar 2} (sut/new-query-params current-match opts new-params-map)))))
+
+  (testing "Updates global"
+    (let [current-match {:query-params {:foo 1 :bar 2}}
+          opts {kws/global-query-params #{:bar}}
+          new-params-map {:bar 3}]
+      (is (= {:bar 3} (sut/new-query-params current-match opts new-params-map))))))
+
+(deftest test-update-query-params!
+  (testing "Calls goto! with updated query params"
+    (let [goto-args (atom [])]
+      (with-redefs [sut/goto! #(swap! goto-args conj %&)
+                    sut/*state* (atom {:data {kws/name :foo} :query-params {:foo "1" :bar "2"}})]
+        (sut/update-query-params! {:foo "2" :baz "3"})
+        (is (= [[:foo kws/query-params {:foo "2" :bar "2" :baz "3"}]] @goto-args))))))
 
 (deftest test-run-views-hooks!
 
@@ -60,8 +86,23 @@
         (is (= [[kws/exit-hook old-match] [kws/enter-hook new-match]] @args))))))
 
 (deftest test-path-to!
-  (is (= "/#/" (sut/path-to! :home {} (rf/router routes))))
-  (is (= "/#/foo" (sut/path-to! :foo {} (rf/router routes))))
-  (is (= "/#/foo?id=1" (sut/path-to! :foo {:query-params {:id 1}} (rf/router routes))))
-  (is (= "/#/bar/1?id=2" (sut/path-to! :bar {:query-params {:id 2} :path-params {:id 1}}
-                                       (rf/router routes)))))
+
+  (testing "No global params"
+    (with-redefs [sut/*state* (atom nil)
+                  sut/*opts*  {}]
+      (is (= "/#/" (sut/path-to! :home {} (rf/router routes))))
+      (is (= "/#/foo" (sut/path-to! :foo {} (rf/router routes))))
+      (is (= "/#/foo?id=1" (sut/path-to! :foo {:query-params {:id 1}} (rf/router routes))))
+      (is (= "/#/bar/1?id=2" (sut/path-to! :bar {:query-params {:id 2} :path-params {:id 1}}
+                                           (rf/router routes))))))
+
+  (testing "With global params"
+    (with-redefs [sut/*state* (atom {:query-params {:foo "1" :bar "2"}})
+                  sut/*opts*  {kws/global-query-params #{:foo}}]
+      (is (= "/#/?foo=1" (sut/path-to! :home {} (rf/router routes))))
+      (is (= "/#/foo?foo=1" (sut/path-to! :foo {} (rf/router routes))))
+      (is (= "/#/foo?foo=1&id=1" (sut/path-to! :foo {:query-params {:id 1}} (rf/router routes))))
+      (is (= "/#/bar/1?foo=1&id=2" (sut/path-to! :bar {:query-params {:id 2} :path-params {:id 1}}
+                                                 (rf/router routes))))
+      (is (= "/#/bar/1?foo=2" (sut/path-to! :bar {:query-params {:foo 2} :path-params {:id 1}}
+                                            (rf/router routes)))))))

--- a/test/ohmycards/web/views/cards_grid/core_test.cljs
+++ b/test/ohmycards/web/views/cards_grid/core_test.cljs
@@ -65,20 +65,20 @@
         [sut/card-display-footer props]
         (tu/comp-seq (sut/card-display props)))))))
 
-(deftest test-main*
+(deftest test-main
 
   (testing "Top level component is a loading wrapper with props"
-    (let [[el props & _] (sut/main* {:state (atom {})})]
+    (let [[el props & _] (sut/main {:state (atom {})})]
       (is (= el loading-wrapper/main))
       (is (= props {:loading? true}))))
 
   (testing "There exists a div with correct class"
-    (is (tu/exists-in-component? :div.cards-grid (tu/comp-seq (sut/main* {:state (atom {})})))))
+    (is (tu/exists-in-component? :div.cards-grid (tu/comp-seq (sut/main {:state (atom {})})))))
 
   (testing "A card has it's card-display rendered"
     (let [card      {kws.card/id "FOO"}
           props     {:state (atom {kws/cards [card]})}
-          component (sut/main* props)]
+          component (sut/main props)]
       (is
        (some
         #(= [sut/card-display (assoc props ::sut/card card)] %)
@@ -86,21 +86,21 @@
 
   (testing "If not cards, renders the empty-msgbox"
     (let [props     {:state (atom {kws/cards []})}
-          component (sut/main* props)]
+          component (sut/main props)]
       (is (tu/exists-in-component? :div.cards-grid__empty-msgbox (tu/comp-seq component)))))
 
   (testing "If `filter-enabled?` is true, renders the fitlering control."
     (let [props     {:state (atom {kws/filter-enabled? true})}
-          component (sut/main* props)]
+          component (sut/main props)]
       (is (tu/exists-in-component? [control-filter/main props] (tu/comp-seq component)))))
 
   (testing "If `filter-enabled?` is false, DO NOT render the fitlering control."
     (let [props     {:state (atom {kws/filter-enabled? nil})}
-          component (sut/main* props)]
+          component (sut/main props)]
       (is (not (tu/exists-in-component? [control-filter/main props] (tu/comp-seq component))))))
 
   (testing "Renders error message with error"
     (is
      (some
       #(= [error-message-box/main {:value "Foo"}] %)
-      (tu/comp-seq (sut/main* {:state (atom {kws/error-message "Foo"})}))))))
+      (tu/comp-seq (sut/main {:state (atom {kws/error-message "Foo"})}))))))

--- a/test/ohmycards/web/views/cards_grid/state_management_test.cljs
+++ b/test/ohmycards/web/views/cards_grid/state_management_test.cljs
@@ -78,14 +78,6 @@
     (testing "Base"
       (is (= expected-params (sut/fetch-cards-params source-params))))))
 
-(deftest test-state-not-initialized?
-
-  (testing "nil -> false"
-    (is (false? (sut/state-initialized? {}))))
-
-  (testing "::ready -> true"
-    (is (true? (sut/state-initialized? {kws.cards-grid/status kws.cards-grid/status-ready})))))
-
 (deftest test-refetch-from-props!
   (with-redefs [sut/refetch! #(do [%1 %2])]
     (is (= [1 2] (sut/refetch-from-props! {:state 1 kws.cards-grid/fetch-cards! 2})))))


### PR DESCRIPTION
- `grid-profile` is a fixed parameter to be kept in the url among
  redirects and routings
- When the grid profile changes, a msg with the new profile is sent so
  that other components can update