### PR TITLE
NEW _46 Don't render current view if login not finished

### DIFF
--- a/src/ohmycards/web/components/current_view/core.cljs
+++ b/src/ohmycards/web/components/current_view/core.cljs
@@ -7,9 +7,10 @@
   - `view`: A reagent component for the current view.
   - `login-view`: The page to render if the user is not logged in.
   - `header-component`: The header to use on every page."
-  [{:keys [state] ::keys [current-user view login-view header-component] :as props}]
-  [:div.current-view
-   (if (login.utils/user-logged-in? current-user)
-     (list ^{:key :header} [header-component]
-           ^{:key :view}   [view])
-     [login-view])])
+  [{:keys [state] ::keys [current-user view login-view header-component loading?] :as props}]
+  (when-not loading?
+    [:div.current-view
+     (if (login.utils/user-logged-in? current-user)
+       (list ^{:key :header} [header-component]
+             ^{:key :view}   [view])
+       [login-view])]))

--- a/src/ohmycards/web/core.cljs
+++ b/src/ohmycards/web/core.cljs
@@ -158,7 +158,8 @@
      ::components.current-view/view (or (-> state ::lenses.routing/match :data kws.routing/view)
                                         home-view)
      ::components.current-view/login-view login-view
-     ::components.current-view/header-component header-component}]
+     ::components.current-view/header-component header-component
+     ::components.current-view/loading? (-> state lenses.login/initialized? not)}]
    [controllers.action-dispatcher/component]
    [services.notify/toast]])
 

--- a/src/ohmycards/web/kws/lenses/login.cljs
+++ b/src/ohmycards/web/kws/lenses/login.cljs
@@ -1,3 +1,4 @@
 (ns ohmycards.web.kws.lenses.login)
 
 (def current-user "The current user, or nil if not logged in. See `kws.user`." ::current-user)
+(def initialized? "True if the login service has finished initialization." ::initialized?)

--- a/src/ohmycards/web/services/login/core.cljs
+++ b/src/ohmycards/web/services/login/core.cljs
@@ -39,6 +39,10 @@
       (let [user (a/<! (get-user/main! opts token))]
         (set-user! user)))))
 
+(defn- set-finished-loading! [state]
+  (log "Login initialized.")
+  (swap! state assoc lenses.login/initialized? true))
+
 ;; API
 (defn init!
   "Initialization logic for the service. Tries to log the user in if he is not yet logged in.
@@ -47,7 +51,9 @@
   [{:keys [state http-fn] :as opts}]
   (log "Initializing...")
   (set! *state* state)
-  (try-login-from-cookies! opts))
+  (a/go
+    (a/<! (try-login-from-cookies! opts))
+    (set-finished-loading! state)))
 
 (defn main
   "Performs login for a given user.

--- a/test/ohmycards/web/components/current_view/core_test.cljs
+++ b/test/ohmycards/web/components/current_view/core_test.cljs
@@ -14,4 +14,7 @@
   (testing "Returns login-page if no user"
     (is (= [:div.current-view [::login-view]]
            (sut/main {::sut/current-user {}
-                      ::sut/login-view   ::login-view})))))
+                      ::sut/login-view   ::login-view}))))
+
+  (testing "Renders nothing if we are loading"
+    (is (nil? (sut/main {::sut/loading? true})))))

--- a/test/ohmycards/web/core_test.cljs
+++ b/test/ohmycards/web/core_test.cljs
@@ -31,7 +31,8 @@
                  {::components.current-view/current-user     ::current-user
                   ::components.current-view/login-view       ::login-view
                   ::components.current-view/view             ::current-view
-                  ::components.current-view/header-component ::header-component}]
+                  ::components.current-view/header-component ::header-component
+                  ::components.current-view/loading?         true}]
                 [controllers.action-dispatcher/component]
                 [services.notify/toast]]
                (sut/current-view* state ::home-view ::login-view ::header-component))))
@@ -40,7 +41,13 @@
         (let [state*    (dissoc state ::lenses.routing/match)
               [_ props] (find-main
                          (sut/current-view* state* ::home-view ::login-view ::header-component))]
-          (is (= ::home-view (::components.current-view/view props))))))))
+          (is (= ::home-view (::components.current-view/view props)))))
+
+      (testing "Receives loading? from login status (false)"
+        (let [state*    (assoc state ::lenses.login/initialized? true)
+              [_ props] (find-main
+                         (sut/current-view* state* ::home-view ::login-view ::header-component))]
+          (is (false? (::components.current-view/loading? props))))))))
 
 (deftest test-contextual-actions-dispatcher-hydra-head!
 


### PR DESCRIPTION
- Current view receives `loading?` argument, and if we are loading
don't render anything.

- Login initialization set's a flag on the state after it's done,
which is used by current-view to determine if loading or not.