### PR TITLE
NEW _1008 Uses visible file input for file upload

### DIFF
--- a/src/ohmycards/web/app/provider.cljs
+++ b/src/ohmycards/web/app/provider.cljs
@@ -21,8 +21,7 @@
             [ohmycards.web.services.fetch-cards.core :as services.fetch-cards]
             [ohmycards.web.services.http :as services.http]
             [ohmycards.web.services.notify :as services.notify]
-            [ohmycards.web.utils.clipboard :as utils.clipboard]
-            [ohmycards.web.services.file-uploader :as services.file-uploader]))
+            [ohmycards.web.utils.clipboard :as utils.clipboard]))
 
 (defn to-clipboard!
   "Sends a text to the clipboard and notifies user on completion."
@@ -88,11 +87,3 @@
   "Provides the login service."
   [login-opts]
   (services.login/main login-opts {:run-http-action-fn run-http-action}))
-
-(defn upload-file!
-  "Uploads a file"
-  []
-  (services.file-uploader/ask-and-upload
-   {::services.file-uploader/notify! notify!
-    ::services.file-uploader/run-http-action run-http-action
-    ::services.file-uploader/to-clipboard! to-clipboard!}))

--- a/src/ohmycards/web/components/dialog/core.cljs
+++ b/src/ohmycards/web/components/dialog/core.cljs
@@ -2,11 +2,25 @@
   (:require [ohmycards.web.icons :as icons]
             [ohmycards.web.kws.components.dialog.core :as kws]))
 
+(defn show!
+  "Displayes the dialog."
+  [{:keys [state] ::kws/keys [on-show!]}]
+  (swap! state assoc kws/active? true)
+  (when on-show!
+    (on-show!)))
+
+(defn hide!
+  "Hidens the dialog."
+  [{:keys [state] ::kws/keys [on-hide!]}]
+  (swap! state assoc kws/active? false)
+  (when on-hide!
+    (on-hide!)))
+
 (defn- header
   "The header of the dialog, with the exit button"
-  [{:keys [state]}]
+  [props]
   [:div.dialog__header
-   [:button.icon-button {:on-click #(swap! state assoc kws/active? false)}
+   [:button.icon-button {:on-click #(hide! props)}
     [icons/close]]])
 
 (defn main

--- a/src/ohmycards/web/components/file_upload_dialog/core.cljs
+++ b/src/ohmycards/web/components/file_upload_dialog/core.cljs
@@ -33,7 +33,8 @@
   [dialog/main (dialog-props props)
    [:input.file-upload-dialog
     {:type "file"
-     :on-change #(on-change! props %)}]])
+     :on-change #(on-change! props %)
+     :autoFocus true}]])
 
 (defn show!
   "Displays the file dialog and waits for the user to select a file.

--- a/src/ohmycards/web/components/file_upload_dialog/core.cljs
+++ b/src/ohmycards/web/components/file_upload_dialog/core.cljs
@@ -1,23 +1,50 @@
 (ns ohmycards.web.components.file-upload-dialog.core
-  (:require [ohmycards.web.components.dialog.core :as dialog]
+  (:require [cljs.core.async :as a]
+            [ohmycards.web.components.dialog.core :as dialog]
+            [ohmycards.web.kws.components.dialog.core :as kws.dialog]
             [reagent.core :as r]))
 
-(defn- dialog-props [{:keys [state]}]
-  {:state (r/cursor state [::dialog])})
+(declare hide!)
+
+(defn- on-hide!
+  "Handles event of hidding the dialog."
+  [{:keys [state] :as props}]
+  (when-let [selected-file-chan (::selected-file-chan @state)]
+    (a/close! selected-file-chan)
+    (swap! state assoc ::selected-file-chan nil)))
+
+(defn- dialog-props [{:keys [state] :as props}]
+  {:state (r/cursor state [::dialog])
+   kws.dialog/on-hide! #(on-hide! props)})
+
+(defn- on-change!
+  "Handles a change for the file input"
+  [{:keys [state] :as props} event]
+  (let [file (some-> event .-target .-files first)]
+    (when-let [file-chan (::selected-file-chan @state)]
+      (a/go
+        (when file
+          (a/>! file-chan file))
+        (hide! props)))))
 
 (defn main
   "A dialog used to upload files."
   [props]
   [dialog/main (dialog-props props)
-   [:input.file-upload-dialog {:type "file"}]])
+   [:input.file-upload-dialog
+    {:type "file"
+     :on-change #(on-change! props %)}]])
 
 (defn show!
   "Displays the file dialog and waits for the user to select a file.
    Returns a channel that will receive the selected file (or be closed)"
-  [props]
-  (dialog/show! (dialog-props props)))
+  [{:keys [state] :as props}]
+  (let [chan (a/chan 1)]
+    (swap! state assoc ::selected-file-chan chan)
+    (dialog/show! (dialog-props props))
+    chan))
 
 (defn hide!
   "Hides the file dialog"
-  [props]
+  [{:keys [state] :as props}]
   (dialog/hide! (dialog-props props)))

--- a/src/ohmycards/web/components/file_upload_dialog/core.cljs
+++ b/src/ohmycards/web/components/file_upload_dialog/core.cljs
@@ -1,17 +1,23 @@
-(ns ohmycards.web.components.file-upload-dialog.core)
+(ns ohmycards.web.components.file-upload-dialog.core
+  (:require [ohmycards.web.components.dialog.core :as dialog]
+            [reagent.core :as r]))
+
+(defn- dialog-props [{:keys [state]}]
+  {:state (r/cursor state [::dialog])})
 
 (defn main
   "A dialog used to upload files."
   [props]
-  [:div "File upload dialog"])
+  [dialog/main (dialog-props props)
+   [:input.file-upload-dialog {:type "file"}]])
 
 (defn show!
   "Displays the file dialog and waits for the user to select a file.
    Returns a channel that will receive the selected file (or be closed)"
   [props]
-  nil)
+  (dialog/show! (dialog-props props)))
 
 (defn hide!
   "Hides the file dialog"
   [props]
-  nil)
+  (dialog/hide! (dialog-props props)))

--- a/src/ohmycards/web/components/file_upload_dialog/core.cljs
+++ b/src/ohmycards/web/components/file_upload_dialog/core.cljs
@@ -1,0 +1,17 @@
+(ns ohmycards.web.components.file-upload-dialog.core)
+
+(defn main
+  "A dialog used to upload files."
+  [props]
+  [:div "File upload dialog"])
+
+(defn show!
+  "Displays the file dialog and waits for the user to select a file.
+   Returns a channel that will receive the selected file (or be closed)"
+  [props]
+  nil)
+
+(defn hide!
+  "Hides the file dialog"
+  [props]
+  nil)

--- a/src/ohmycards/web/controllers/action_dispatcher/core.cljs
+++ b/src/ohmycards/web/controllers/action_dispatcher/core.cljs
@@ -15,6 +15,9 @@
 (defonce ^:dynamic ^:private *controller* nil)
 
 ;; Impl
+(defn- dialog-props [controller]
+  {:state (::dialog-state controller)})
+
 (defn- show*
   "Pure implementation of show!
   - `controller-opts` is the options for the controller.
@@ -22,13 +25,13 @@
   [controller-opts hydra-head]
   (when hydra-head
     (reset! (::current-hydra-head-atom controller-opts) hydra-head)
-    (swap! (::dialog-state controller-opts) assoc kws.dialog/active? true)
+    (dialog/show! (dialog-props controller-opts))
     (action-dispatcher/reset-state (::action-dispatcher-state controller-opts))))
 
 (defn- close*
   "Pure implementation of close!"
-  [{::keys [dialog-state]}]
-  (swap! dialog-state assoc kws.dialog/active? false))
+  [controller-opts]
+  (dialog/hide! (dialog-props controller-opts)))
 
 (defn- component*
   "Pure implementation of component"

--- a/src/ohmycards/web/controllers/file_upload_dialog/core.cljs
+++ b/src/ohmycards/web/controllers/file_upload_dialog/core.cljs
@@ -1,16 +1,26 @@
 (ns ohmycards.web.controllers.file-upload-dialog.core
-  (:require [ohmycards.web.app.state :as app.state]
+  (:require [ohmycards.web.app.provider :as app.provider]
+            [ohmycards.web.app.state :as app.state]
             [ohmycards.web.components.file-upload-dialog.core
              :as
-             components.file-upload-dialog]))
+             components.file-upload-dialog]
+            [ohmycards.web.services.file-uploader :as services.file-uploader]))
 
 (defn ^:private props
   "Returns the props for the file-upload-dialog instance."
   []
   {:state (app.state/state-cursor :controllers.file-upload-dialog)})
 
-(defn show! [] (components.file-upload-dialog/show! (props)))
-(defn hide! [] (components.file-upload-dialog/hide! (props)))
+(defn- show! [] (components.file-upload-dialog/show! (props)))
+(defn- hide! [] (components.file-upload-dialog/hide! (props)))
+(defn upload-file!
+  "Asks the user for a file and uploads it"
+  []
+  (services.file-uploader/ask-and-upload
+   {::services.file-uploader/ask-for-file! show!
+    ::services.file-uploader/notify! app.provider/notify!
+    ::services.file-uploader/run-http-action app.provider/run-http-action
+    ::services.file-uploader/to-clipboard! app.provider/to-clipboard!}))
 
 (defn component
   "The ReactJs component for this instance of file-upload-dialog"

--- a/src/ohmycards/web/controllers/file_upload_dialog/core.cljs
+++ b/src/ohmycards/web/controllers/file_upload_dialog/core.cljs
@@ -1,0 +1,15 @@
+(ns ohmycards.web.controllers.file-upload-dialog.core
+  (:require [ohmycards.web.components.file-upload-dialog.core :as components.file-upload-dialog]))
+
+(defn ^:private props
+  "Returns the props for the file-upload-dialog instance."
+  []
+  {})
+
+(defn show! [] (components.file-upload-dialog/show! (props)))
+(defn hide! [] (components.file-upload-dialog/hide! (props)))
+
+(defn component
+  "The ReactJs component for this instance of file-upload-dialog"
+  []
+  [components.file-upload-dialog/main (props)])

--- a/src/ohmycards/web/controllers/file_upload_dialog/core.cljs
+++ b/src/ohmycards/web/controllers/file_upload_dialog/core.cljs
@@ -1,10 +1,13 @@
 (ns ohmycards.web.controllers.file-upload-dialog.core
-  (:require [ohmycards.web.components.file-upload-dialog.core :as components.file-upload-dialog]))
+  (:require [ohmycards.web.app.state :as app.state]
+            [ohmycards.web.components.file-upload-dialog.core
+             :as
+             components.file-upload-dialog]))
 
 (defn ^:private props
   "Returns the props for the file-upload-dialog instance."
   []
-  {})
+  {:state (app.state/state-cursor :controllers.file-upload-dialog)})
 
 (defn show! [] (components.file-upload-dialog/show! (props)))
 (defn hide! [] (components.file-upload-dialog/hide! (props)))

--- a/src/ohmycards/web/core.cljs
+++ b/src/ohmycards/web/core.cljs
@@ -303,7 +303,7 @@
     {kws.hydra/shortcut    \u
      kws.hydra/description "Upload File"
      kws.hydra/type        kws.hydra/leaf
-     kws.hydra.leaf/value  #(app.provider/upload-file!)}
+     kws.hydra.leaf/value  #(controllers.file-upload-dialog/upload-file!)}
     {kws.hydra/shortcut    \a
      kws.hydra/description "About the app"
      kws.hydra/type        kws.hydra/leaf

--- a/src/ohmycards/web/core.cljs
+++ b/src/ohmycards/web/core.cljs
@@ -67,7 +67,8 @@
             [ohmycards.web.views.login.core :as views.login]
             [ohmycards.web.views.new-card.core :as new-card]
             [ohmycards.web.views.profiles.core :as views.profiles]
-            [reagent.dom :as r.dom]))
+            [reagent.dom :as r.dom]
+            [ohmycards.web.controllers.file-upload-dialog.core :as controllers.file-upload-dialog]))
 
 ;; -------------------------
 ;; View instances
@@ -177,6 +178,7 @@
      ::components.current-view/header-component header-component
      ::components.current-view/loading? (-> state lenses.login/initialized? not)}]
    [controllers.action-dispatcher/component]
+   [controllers.file-upload-dialog/component]
    [services.notify/toast]])
 
 (defn current-view []
@@ -358,4 +360,3 @@
   (controllers.cards-grid/init!)
 
   (mount-root))
- 

--- a/src/ohmycards/web/kws/components/dialog/core.cljs
+++ b/src/ohmycards/web/kws/components/dialog/core.cljs
@@ -1,3 +1,8 @@
 (ns ohmycards.web.kws.components.dialog.core)
 
+;; State
 (def active? "Is the dialog active?" ::active?)
+
+;; Props
+(def on-show! "Callback called when the dialog is shown" ::on-show!)
+(def on-hide! "Callback called when the dialog is hidden" ::on-hide!)

--- a/src/ohmycards/web/services/file_uploader.cljs
+++ b/src/ohmycards/web/services/file_uploader.cljs
@@ -17,27 +17,9 @@
   (protocols.http/do-after! [_ _ key]
     ((::to-clipboard! opts) (url-for-key key))))
 
-(defn ask-for-file!
-  "Asks the user for a file to be uploaded."
-  []
-  (let [el        (js/document.createElement "input")
-        file-chan (a/chan 1)]
-    (set! (.-type el) "file")
-    (set! (.-hidden el) true)
-    (set! (.-onchange el)
-          (fn [_]
-            (a/go
-              (if-let [file (->> el .-files js->clj first)]
-                (a/>! file-chan file)
-                (a/close! file-chan)))))
-    (js/document.body.appendChild el)
-    (.click el)
-    (js/document.body.removeChild el)
-    file-chan))
-
 (defn ask-and-upload [opts]
   "Asks the user for a file and uploads it"
-  (let [ask-for-file!   (::ask-for-file!   opts ask-for-file!)
+  (let [ask-for-file!   (::ask-for-file!   opts (constantly nil))
         notify!         (::notify!         opts (constantly nil))
         run-http-action (::run-http-action opts (constantly nil))]
     (a/go

--- a/src/scss/_dialog.scss
+++ b/src/scss/_dialog.scss
@@ -1,6 +1,6 @@
 .dialog {
 
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 100%;

--- a/src/scss/_file-upload-dialog.scss
+++ b/src/scss/_file-upload-dialog.scss
@@ -1,0 +1,3 @@
+.file-upload-dialog {
+    
+}

--- a/src/scss/site.scss
+++ b/src/scss/site.scss
@@ -31,6 +31,7 @@
 @import "toast";
 @import "card-history-displayer/core";
 @import "profiles";
+@import "file-upload-dialog";
 
 @import "buttons";
 

--- a/src/test_ns_requires.cljs
+++ b/src/test_ns_requires.cljs
@@ -19,6 +19,7 @@
 [ohmycards.web.components.card-history-displayer.field-update-displayer-test]
 [ohmycards.web.components.current-view.core-test]
 [ohmycards.web.components.dialog.core-test]
+[ohmycards.web.components.file-upload-dialog.core-test]
 [ohmycards.web.components.form.core-test]
 [ohmycards.web.components.hydra.core-test]
 [ohmycards.web.components.inputs.combobox-test]

--- a/test/ohmycards/web/components/dialog/core_test.cljs
+++ b/test/ohmycards/web/components/dialog/core_test.cljs
@@ -19,3 +19,32 @@
     (testing "Renders header inside contents if active"
       (let [props {:state (gen-state)}]
         (is (tu/exists-in-component? [sut/header props] (sut/main props)))))))
+
+
+(deftest test-show!
+
+  (testing "Set's active to true"
+    (let [state (atom {kws/active? false})
+          props {:state state}]
+      (sut/show! props)
+      (is (true? (kws/active? @state)))))
+
+  (testing "Calls on-show!"
+    (let [calls (atom 0)
+          props {kws/on-show! #(swap! calls inc) :state (atom {})}]
+      (sut/show! props)
+      (is (= 1 @calls)))))
+
+(deftest test-hide!
+
+  (testing "Set's active to false"
+    (let [state (atom {kws/active? true})
+          props {:state state}]
+      (sut/hide! props)
+      (is (false? (kws/active? @state)))))
+
+  (testing "Calls on-hide!"
+    (let [calls (atom 0)
+          props {kws/on-hide! #(swap! calls inc) :state (atom {})}]
+      (sut/hide! props)
+      (is (= 1 @calls)))))

--- a/test/ohmycards/web/components/file_upload_dialog/core_test.cljs
+++ b/test/ohmycards/web/components/file_upload_dialog/core_test.cljs
@@ -1,4 +1,46 @@
 (ns ohmycards.web.components.file-upload-dialog.core-test
-  (:require [ohmycards.web.components.file-upload-dialog.core :as sut]
-            [cljs.test :refer-macros [is are deftest testing use-fixtures async]]))
+  (:require [cljs.core.async :as a]
+            [cljs.test :refer-macros [are async deftest is testing use-fixtures]]
+            [ohmycards.web.components.dialog.core :as dialog]
+            [ohmycards.web.components.file-upload-dialog.core :as sut]
+            [reagent.core :as r]))
 
+(deftest test-integration-on-change!--does-nothing-if-no-file
+  (async
+   done
+   (let [file-chan (a/chan 1)
+         state (r/atom {::sut/selected-file-chan file-chan})
+         props {:state state}
+         event (clj->js {:target {:files []}})]
+     (sut/on-change! props event)
+     (a/go
+       (is (nil? (a/<! file-chan)))
+       (done)))))
+
+(deftest test-integration-on-change!--sends-file-to-chan
+  (async
+   done
+   (let [file-chan (a/chan 1)
+         state (r/atom {::sut/selected-file-chan file-chan})
+         props {:state state}
+         event (clj->js {:target {:files ["file"]}})]
+     (sut/on-change! props event)
+     (a/go
+       (is (= "file" (a/<! file-chan)))
+       (done)))))
+
+(deftest test-integration-show-and-hide
+  (async
+   done
+   (let [dialog-show-calls (atom 0)]
+     (with-redefs [dialog/show! #(swap! dialog-show-calls inc)]
+       (let [state (r/atom {})
+             props {:state state}
+             chan  (sut/show! props)]
+         (is (= 1 @dialog-show-calls))
+         (is (= chan (::sut/selected-file-chan @state)))
+         (sut/hide! props)
+         (is (nil? (::sut/selected-file-chan @state)))
+         (a/go
+           (is (nil? (a/<! chan)))
+           (done)))))))

--- a/test/ohmycards/web/components/file_upload_dialog/core_test.cljs
+++ b/test/ohmycards/web/components/file_upload_dialog/core_test.cljs
@@ -1,0 +1,4 @@
+(ns ohmycards.web.components.file-upload-dialog.core-test
+  (:require [ohmycards.web.components.file-upload-dialog.core :as sut]
+            [cljs.test :refer-macros [is are deftest testing use-fixtures async]]))
+

--- a/test/ohmycards/web/core_test.cljs
+++ b/test/ohmycards/web/core_test.cljs
@@ -5,6 +5,9 @@
             [ohmycards.web.controllers.action-dispatcher.core
              :as
              controllers.action-dispatcher]
+            [ohmycards.web.controllers.file-upload-dialog.core
+             :as
+             controllers.file-upload-dialog]
             [ohmycards.web.core :as sut]
             [ohmycards.web.kws.hydra.branch :as kws.hydra.branch]
             [ohmycards.web.kws.hydra.core :as kws.hydra]
@@ -34,6 +37,7 @@
                   ::components.current-view/header-component ::header-component
                   ::components.current-view/loading?         true}]
                 [controllers.action-dispatcher/component]
+                [controllers.file-upload-dialog/component]
                 [services.notify/toast]]
                (sut/current-view* state ::home-view ::login-view ::header-component))))
 


### PR DESCRIPTION
Because we can not fire "click" event on inputs of type "file" in firefox, we use a dialog with a file input that the user has to click
